### PR TITLE
Fixing require admin

### DIFF
--- a/api/comments.js
+++ b/api/comments.js
@@ -6,6 +6,7 @@ import { getCommentsByInstrumentId, editComment, deleteComment } from #db/querie
 
 import requireBody from "#middleware/requireBody";
 import requireUser from "#middleware/requireUser";
+import requireAdmin from "#middleware/requireAdmin";
 
 router
     .route("/:id")

--- a/middleware/requireAdmin.js
+++ b/middleware/requireAdmin.js
@@ -1,5 +1,5 @@
 /** Requires a logged-in user with the admin boolean set to true */
-export default async function requireUser(req, res, next) {
+export default async function requireAdmin(req, res, next) {
   if (!req.user.admin)
     return res
       .status(403)


### PR DESCRIPTION
Fixed requireAdmin so the function was named correctly, and also double checked that all API routers were correctly importing requireAdmin, and that, where used in API endpoints, requireAdmin is always preceded by requireUser.